### PR TITLE
Add findOrCreate functions from Toolbox PR

### DIFF
--- a/include/SimpleIniParser/Ini.hpp
+++ b/include/SimpleIniParser/Ini.hpp
@@ -34,10 +34,13 @@ namespace simpleIniParser {
             ~Ini();
             std::string build();
             IniOption * findFirstOption(std::string term, bool caseSensitive = true, IniOptionType type = IniOptionType::Any, IniOptionSearchField field = IniOptionSearchField::Key);
+            IniOption * findOrCreateFirstOption(std::string key, std::string val, bool caseSensitive = true, IniOptionType type = IniOptionType::Any, IniOptionSearchField field = IniOptionSearchField::Key);
             IniSection * findSection(std::string term, bool caseSensitive = true, IniSectionType type = IniSectionType::Any);
+            IniSection * findOrCreateSection(std::string term, bool caseSensitive = true, IniSectionType type = IniSectionType::Any);
             bool writeToFile(std::string path);
             static Ini * parseFile(std::string path);
             static Ini * parseFileWithMagic(std::string path, std::string magic);
+            static Ini * parseOrCreateFile(std::string path, std::string magic="");
 
         private:
             static Ini * _parseContent(std::stringstream * content, std::string magic);

--- a/include/SimpleIniParser/IniSection.hpp
+++ b/include/SimpleIniParser/IniSection.hpp
@@ -40,6 +40,7 @@ namespace simpleIniParser {
             IniSection(IniSectionType type, std::string value);
             ~IniSection();
             IniOption * findFirstOption(std::string key, bool caseSensitive = true, IniOptionType type = IniOptionType::Any, IniOptionSearchField field = IniOptionSearchField::Key);
+            IniOption * findOrCreateFirstOption(std::string key, std::string val, bool caseSensitive = true, IniOptionType type = IniOptionType::Any, IniOptionSearchField field = IniOptionSearchField::Key);
             std::string build();
             static IniSection * parse(std::string line, bool parseComments);
     };

--- a/source/SimpleIniParser/Ini.cpp
+++ b/source/SimpleIniParser/Ini.cpp
@@ -84,6 +84,18 @@ namespace simpleIniParser {
         return (*it);
     }
 
+
+    IniOption * Ini::findOrCreateFirstOption(string key, string val, bool caseSensitive, IniOptionType type, IniOptionSearchField field) {
+        auto it = findFirstOption(key, caseSensitive, type, field);
+        if (it == nullptr)
+        {
+            it = new IniOption(type, key, val);
+            options.push_back(it);
+        }
+
+        return it;
+    }
+
     IniSection * Ini::findSection(string term, bool caseSensitive, IniSectionType type) {
         if (!caseSensitive) {
             IniStringHelper::toupper(term);
@@ -102,6 +114,17 @@ namespace simpleIniParser {
             return nullptr;
 
         return (*it);
+    }
+
+    IniSection * Ini::findOrCreateSection(string term, bool caseSensitive, IniSectionType type) {
+        auto it = findSection(term, caseSensitive, type);
+        if (it == nullptr)
+        {
+            it = new IniSection(type, term);
+            sections.push_back(it);
+        }
+
+        return it;
     }
 
     bool Ini::writeToFile(string path) {
@@ -148,6 +171,13 @@ namespace simpleIniParser {
         }
         
         return _parseContent(&buffer, magic);
+    }
+
+    Ini * Ini::parseOrCreateFile(string path, string magic) {
+        auto it = Ini::parseFileWithMagic(path, magic);
+        if (it == nullptr)
+            it = new Ini();
+        return it;
     }
 
     Ini * Ini::_parseContent(stringstream * content, string magic) {

--- a/source/SimpleIniParser/IniSection.cpp
+++ b/source/SimpleIniParser/IniSection.cpp
@@ -65,6 +65,17 @@ namespace simpleIniParser {
         return (*it);
     }
 
+    IniOption * IniSection::findOrCreateFirstOption(string key, string val, bool caseSensitive, IniOptionType type, IniOptionSearchField field) {
+        auto it = findFirstOption(key, caseSensitive, type, field);
+        if (it == nullptr)
+        {
+            it = new IniOption(type, key, val);
+            options.push_back(it);
+        }
+
+        return it;
+    }
+
     string IniSection::build() {
         switch (type) {
             case IniSectionType::HekateCaption:


### PR DESCRIPTION
[Link to suggestion](https://github.com/AtlasNX/Kosmos-Toolbox/pull/19#discussion_r357338265)

This adds the function alternatives to parse* or find* functions. It tries to find/parse the file, and if it fails, it returns a new instance of the object, essentially eliminating the need to check for errors at every function.

For `findOrCreateSection()` and `findOrCreateFirstOption()`, the created objects will be automatically appended to the parent object.

For `findOrCreateFirstOption()`, the user must also provide the default value for the created option.